### PR TITLE
Add .env to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 server/public
 vite.config.ts.*
 *.tar.gz
+.env


### PR DESCRIPTION
## Summary
- Adds `.env` to `.gitignore` to prevent API keys and secrets from being accidentally committed

## Test plan
- [ ] Verify `.env` files are excluded from `git status` after cloning