### PR TITLE
Run-level Phase 1 (Layer A): deterministic record/replay via ModelClient + run_artifacts

### DIFF
--- a/server/modelClient.ts
+++ b/server/modelClient.ts
@@ -1,0 +1,224 @@
+// ModelClient — deterministic record/replay layer for vendor LLM calls.
+//
+// Phase 1 of the run-level integration spec (issue #12). The goal is to make
+// model calls reproducible without re-spending API budget: every live call is
+// captured as a content-addressable artifact (keyed by a hash of the exact
+// request), and a later "replay" run looks the response up by that hash instead
+// of hitting the network. This is what lets evals be re-parsed / re-scored
+// deterministically, and it separates code/scoring changes (deterministic) from
+// model sampling noise (the statistical-delta layer, Phase 2).
+//
+// Design notes:
+//   - This module is intentionally store-agnostic and provider-agnostic: the
+//     artifact store and the actual vendor call are both injected. That keeps
+//     the core pure and unit-testable with no DB and no API keys.
+//   - Default behavior is a no-op wrapper: with no env flags set the client runs
+//     in `live` mode with capture OFF, so existing runs are byte-for-byte
+//     unchanged (only an extra, cheap hash computation is added).
+//   - Capture is fail-safe: a store error is logged but never thrown into the
+//     model path, so a recording failure can never break a production run.
+
+import { createHash } from "crypto";
+
+export type ModelClientMode = "live" | "replay";
+
+// A single, normalized chat message as the wrappers already pass them around.
+export interface ModelMessage {
+  role: string;
+  content: string;
+}
+
+// The exact, hashable description of a model request. Anything that can change
+// the model's output should live here so it participates in the request hash.
+export interface ModelRequest {
+  provider: string;
+  model: string;
+  messages: ModelMessage[];
+  // Sampling / decoding params (max_tokens, temperature, ...). Optional so that
+  // wrappers which set nothing still hash to a stable value.
+  params?: Record<string, unknown>;
+}
+
+// Token usage, mirrored from shared/schema's TokenUsage to avoid a cross-import
+// cycle (server -> shared -> server). Structurally identical.
+export interface ModelUsage {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+}
+
+// What a vendor wrapper returns and what we replay. The optional fields are
+// provenance captured into the artifact (issue #12): the resolved model
+// snapshot, the finish reason, and the unparsed provider payload.
+export interface ModelResult {
+  content: string;
+  usage?: ModelUsage;
+  modelVersion?: string;
+  finishReason?: string;
+  raw?: unknown;
+}
+
+// Optional run context. When present, the captured artifact is linked to a run
+// (and ordered within it), which is what makes replayRun(runId) possible.
+export interface ModelCallContext {
+  runId?: string;
+  chatbotId?: string;
+  stepOrder?: number;
+}
+
+// A persisted record of one model call.
+export interface RunArtifact {
+  requestHash: string;
+  provider: string;
+  model: string;
+  request: ModelRequest;
+  content: string;
+  usage?: ModelUsage;
+  latencyMs: number;
+  runId?: string;
+  chatbotId?: string;
+  stepOrder?: number;
+  modelVersion?: string;
+  finishReason?: string;
+  responseRaw?: unknown;
+}
+
+// The minimal persistence contract the client needs. Implemented by the DB in
+// storage.ts; implemented in-memory by the unit tests.
+export interface ArtifactStore {
+  getByHash(requestHash: string): Promise<RunArtifact | undefined>;
+  put(artifact: RunArtifact): Promise<void>;
+}
+
+// Stable JSON: object keys are emitted in sorted order at every depth so that
+// two semantically-equal requests serialize identically. Array order is
+// preserved (message order is significant).
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return "[" + value.map(stableStringify).join(",") + "]";
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return (
+    "{" +
+    keys
+      .map((k) => JSON.stringify(k) + ":" + stableStringify(obj[k]))
+      .join(",") +
+    "}"
+  );
+}
+
+// Content-addressable key for a request. Same provider+model+messages+params
+// => same hash => replayable. Changing any of them yields a different hash.
+export function computeRequestHash(request: ModelRequest): string {
+  const canonical = stableStringify({
+    provider: request.provider,
+    model: request.model,
+    messages: request.messages,
+    params: request.params ?? {},
+  });
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+export interface ModelClientOptions {
+  mode?: ModelClientMode;
+  capture?: boolean;
+  // Injected so tests can assert timing without a real clock; defaults to
+  // Date.now in production.
+  now?: () => number;
+  // Sink for non-fatal capture/replay warnings; defaults to console.warn.
+  logger?: (message: string) => void;
+}
+
+export class ReplayMissError extends Error {
+  constructor(public requestHash: string) {
+    super(`No artifact found for request hash ${requestHash} (replay mode)`);
+    this.name = "ReplayMissError";
+  }
+}
+
+export class ModelClient {
+  private readonly mode: ModelClientMode;
+  private readonly capture: boolean;
+  private readonly now: () => number;
+  private readonly logger: (message: string) => void;
+
+  constructor(
+    private readonly store: ArtifactStore,
+    options: ModelClientOptions = {},
+  ) {
+    this.mode = options.mode ?? "live";
+    this.capture = options.capture ?? false;
+    this.now = options.now ?? Date.now;
+    this.logger = options.logger ?? ((m) => console.warn(m));
+  }
+
+  // Run a model request. In `live` mode it calls `liveCall` (the real vendor
+  // request) and, if capture is on, persists the artifact. In `replay` mode it
+  // returns the stored response for this request hash and never calls the
+  // network; a miss throws ReplayMissError so incomplete recordings surface
+  // loudly rather than silently falling back to a paid call.
+  async complete(
+    request: ModelRequest,
+    liveCall: () => Promise<ModelResult>,
+    ctx: ModelCallContext = {},
+  ): Promise<ModelResult> {
+    const requestHash = computeRequestHash(request);
+
+    if (this.mode === "replay") {
+      const existing = await this.store.getByHash(requestHash);
+      if (!existing) throw new ReplayMissError(requestHash);
+      return { content: existing.content, usage: existing.usage };
+    }
+
+    const startedAt = this.now();
+    const result = await liveCall();
+    const latencyMs = this.now() - startedAt;
+
+    if (this.capture) {
+      const artifact: RunArtifact = {
+        requestHash,
+        provider: request.provider,
+        model: request.model,
+        request,
+        content: result.content,
+        usage: result.usage,
+        latencyMs,
+        runId: ctx.runId,
+        chatbotId: ctx.chatbotId,
+        stepOrder: ctx.stepOrder,
+        modelVersion: result.modelVersion,
+        finishReason: result.finishReason,
+        responseRaw: result.raw,
+      };
+      // Fail-safe: a capture error must never break the model path.
+      try {
+        await this.store.put(artifact);
+      } catch (err) {
+        this.logger(
+          `[modelClient] failed to capture artifact ${requestHash}: ${String(err)}`,
+        );
+      }
+    }
+
+    return result;
+  }
+}
+
+// Deterministically reconstruct the model calls of a prior run from its
+// captured artifacts, ordered by step. This is the foundation the spec calls
+// "re-parse / re-score from artifacts": it returns the exact recorded model
+// outputs with zero API spend. Full re-scoring through the orchestration is
+// Phase 2; this provides the deterministic record it will build on.
+export async function replayRun(
+  store: { getByRun(runId: string): Promise<RunArtifact[]> },
+  runId: string,
+): Promise<RunArtifact[]> {
+  const artifacts = await store.getByRun(runId);
+  return [...artifacts].sort(
+    (a, b) => (a.stepOrder ?? 0) - (b.stepOrder ?? 0),
+  );
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -11,6 +11,7 @@ import { readFileSync } from "fs";
 import { join } from "path";
 import cron from "node-cron";
 import { ESCALATION_LADDER, scenarioConfigs, escalationBeats } from "./wargameConfig";
+import { ModelClient, replayRun, type ArtifactStore, type ModelCallContext } from "./modelClient";
 
 // Read app version from package.json once at startup
 let APP_VERSION = "1.0.0";
@@ -49,6 +50,19 @@ const openrouter = process.env.AI_INTEGRATIONS_OPENROUTER_API_KEY ? new OpenAI({
   apiKey: process.env.AI_INTEGRATIONS_OPENROUTER_API_KEY,
   baseURL: process.env.AI_INTEGRATIONS_OPENROUTER_BASE_URL,
 }) : null;
+
+// Record/replay layer for model calls (issue #12, Phase 1). With no env flags
+// set this is a transparent pass-through (live mode, capture off), so existing
+// runs are unchanged. Set RUN_ARTIFACTS_CAPTURE=1 to record artifacts and
+// MODEL_CLIENT_MODE=replay to serve recorded responses without hitting the API.
+const artifactStore: ArtifactStore = {
+  getByHash: (hash) => storage.getRunArtifactByHash(hash),
+  put: (artifact) => storage.createRunArtifact(artifact),
+};
+const modelClient = new ModelClient(artifactStore, {
+  mode: process.env.MODEL_CLIENT_MODE === "replay" ? "replay" : "live",
+  capture: process.env.RUN_ARTIFACTS_CAPTURE === "1",
+});
 
 // Email client for notifications
 const resend = process.env.RESEND_API_KEY ? new Resend(process.env.RESEND_API_KEY) : null;
@@ -429,26 +443,13 @@ async function performEvaluation(runId: string, run: any, session: any, chatbotI
     // Call the evaluator AI
     const startTime = Date.now();
     try {
-      let evalResult: AICallResult = { content: "" };
-      
-      switch (evaluatorChatbot.provider) {
-        case "openai":
-          evalResult = await callOpenAI(evaluatorChatbot.model, conversationHistory);
-          break;
-        case "anthropic":
-          evalResult = await callAnthropic(evaluatorChatbot.model, conversationHistory);
-          break;
-        case "gemini":
-          evalResult = await callGemini(evaluatorChatbot.model, conversationHistory);
-          break;
-        case "xai":
-          evalResult = await callXAI(evaluatorChatbot.model, conversationHistory);
-          break;
-        case "openrouter":
-          evalResult = await callOpenRouter(evaluatorChatbot.model, conversationHistory);
-          break;
-      }
-      
+      const evalResult = await runModel(
+        evaluatorChatbot.provider,
+        evaluatorChatbot.model,
+        conversationHistory,
+        { runId, chatbotId: evaluatorChatbot.id, stepOrder: 1000 + chatbotIds.indexOf(chatbotId) },
+      );
+
       const latencyMs = Date.now() - startTime;
       const evaluationContent = evalResult.content;
       
@@ -561,15 +562,21 @@ async function callOpenAI(model: string, messages: { role: string; content: stri
     completionTokens: response.usage.completion_tokens,
     totalTokens: response.usage.total_tokens,
   } : undefined;
-  return { content: response.choices[0]?.message?.content || "", usage };
+  return {
+    content: response.choices[0]?.message?.content || "",
+    usage,
+    modelVersion: response.model,
+    finishReason: response.choices[0]?.finish_reason ?? undefined,
+    raw: response,
+  };
 }
 
 async function callAnthropic(model: string, messages: { role: string; content: string }[]): Promise<AICallResult> {
   const systemMessages = messages.filter(m => m.role === "system");
   const conversationMessages = messages.filter(m => m.role !== "system");
-  
+
   const systemPrompt = systemMessages.map(m => m.content).join("\n\n") || undefined;
-  
+
   if (!anthropic) throw new Error("AI_INTEGRATIONS_ANTHROPIC_API_KEY not configured");
   const response = await anthropic.messages.create({
     model,
@@ -587,35 +594,47 @@ async function callAnthropic(model: string, messages: { role: string; content: s
     completionTokens: response.usage.output_tokens,
     totalTokens: response.usage.input_tokens + response.usage.output_tokens,
   } : undefined;
-  return { content, usage };
+  return {
+    content,
+    usage,
+    modelVersion: response.model,
+    finishReason: response.stop_reason ?? undefined,
+    raw: response,
+  };
 }
 
 async function callGemini(model: string, messages: { role: string; content: string }[]): Promise<AICallResult> {
   const systemMessages = messages.filter(m => m.role === "system");
   const conversationMessages = messages.filter(m => m.role !== "system");
-  
-  const systemPrefix = systemMessages.length > 0 
+
+  const systemPrefix = systemMessages.length > 0
     ? systemMessages.map(m => m.content).join("\n\n") + "\n\n---\n\n"
     : "";
-  
+
   const contents = conversationMessages.map((m, i) => ({
     role: m.role === "assistant" ? "model" : "user",
     parts: [{ text: i === 0 && systemPrefix ? systemPrefix + m.content : m.content }],
   }));
-  
+
   if (!gemini) throw new Error("AI_INTEGRATIONS_GEMINI_API_KEY not configured");
   const response = await gemini.models.generateContent({
     model,
     contents,
   });
-  
+
   const meta = response.usageMetadata;
   const usage: TokenUsage | undefined = meta ? {
     promptTokens: meta.promptTokenCount ?? 0,
     completionTokens: meta.candidatesTokenCount ?? 0,
     totalTokens: meta.totalTokenCount ?? ((meta.promptTokenCount ?? 0) + (meta.candidatesTokenCount ?? 0)),
   } : undefined;
-  return { content: response.text || "", usage };
+  return {
+    content: response.text || "",
+    usage,
+    modelVersion: (response as { modelVersion?: string }).modelVersion,
+    finishReason: response.candidates?.[0]?.finishReason as string | undefined,
+    raw: response,
+  };
 }
 
 async function callXAI(model: string, messages: { role: string; content: string }[]): Promise<AICallResult> {
@@ -635,7 +654,13 @@ async function callXAI(model: string, messages: { role: string; content: string 
     completionTokens: response.usage.completion_tokens,
     totalTokens: response.usage.total_tokens,
   } : undefined;
-  return { content: response.choices[0]?.message?.content || "", usage };
+  return {
+    content: response.choices[0]?.message?.content || "",
+    usage,
+    modelVersion: response.model,
+    finishReason: response.choices[0]?.finish_reason ?? undefined,
+    raw: response,
+  };
 }
 
 async function callOpenRouter(model: string, messages: { role: string; content: string }[]): Promise<AICallResult> {
@@ -653,7 +678,46 @@ async function callOpenRouter(model: string, messages: { role: string; content: 
     completionTokens: response.usage.completion_tokens,
     totalTokens: response.usage.total_tokens,
   } : undefined;
-  return { content: response.choices[0]?.message?.content || "", usage };
+  return {
+    content: response.choices[0]?.message?.content || "",
+    usage,
+    modelVersion: response.model,
+    finishReason: response.choices[0]?.finish_reason ?? undefined,
+    raw: response,
+  };
+}
+
+// Sampling params each adapter sends, captured into the request envelope and
+// the request hash. Mirrors the constants in the call* adapters above; keep in
+// sync if an adapter's params change.
+const PROVIDER_PARAMS: Record<string, Record<string, unknown>> = {
+  openai: { max_completion_tokens: 2048 },
+  anthropic: { max_tokens: 2048 },
+  gemini: {},
+  xai: { max_tokens: 2048 },
+  openrouter: { max_tokens: 4096 },
+};
+
+// Single dispatch point for every model call. Selects the provider adapter and
+// routes it through the record/replay layer (issue #12); pass `ctx` to link the
+// call to a run so replayRun() can reconstruct it.
+async function runModel(
+  provider: string,
+  model: string,
+  messages: { role: string; content: string }[],
+  ctx: ModelCallContext = {},
+): Promise<AICallResult> {
+  const request = { provider, model, messages, params: PROVIDER_PARAMS[provider] ?? {} };
+  return modelClient.complete(request, () => {
+    switch (provider) {
+      case "openai": return callOpenAI(model, messages);
+      case "anthropic": return callAnthropic(model, messages);
+      case "gemini": return callGemini(model, messages);
+      case "xai": return callXAI(model, messages);
+      case "openrouter": return callOpenRouter(model, messages);
+      default: throw new Error(`Unknown provider: ${provider}`);
+    }
+  }, ctx);
 }
 
 // CSV cell escaping — wraps value in quotes, doubles any internal quotes
@@ -848,6 +912,11 @@ export async function registerRoutes(
       // Get prompts sorted by order
       const sortedPrompts = session.prompts.sort((a, b) => a.order - b.order);
 
+      // Monotonic step index across all model calls in this run, used to order
+      // captured artifacts for replayRun() (issue #12). Shared across the
+      // parallel chatbots so each recorded call gets a distinct position.
+      let artifactStep = 0;
+
       // Process each chatbot - they run in parallel, but each chatbot processes rounds sequentially
       const chatbotPromises = parsed.data.chatbotIds.map(async (chatbotId) => {
         const chatbot = availableChatbots.find(c => c.id === chatbotId);
@@ -873,25 +942,12 @@ export async function registerRoutes(
 
           const startTime = Date.now();
           try {
-            let result: AICallResult = { content: "" };
-            
-            switch (chatbot.provider) {
-              case "openai":
-                result = await callOpenAI(chatbot.model, conversationHistory);
-                break;
-              case "anthropic":
-                result = await callAnthropic(chatbot.model, conversationHistory);
-                break;
-              case "gemini":
-                result = await callGemini(chatbot.model, conversationHistory);
-                break;
-              case "xai":
-                result = await callXAI(chatbot.model, conversationHistory);
-                break;
-              case "openrouter":
-                result = await callOpenRouter(chatbot.model, conversationHistory);
-                break;
-            }
+            const result = await runModel(
+              chatbot.provider,
+              chatbot.model,
+              conversationHistory,
+              { runId: run.id, chatbotId, stepOrder: artifactStep++ },
+            );
 
             const latencyMs = Date.now() - startTime;
             const content = result.content;
@@ -1146,6 +1202,27 @@ export async function registerRoutes(
     } catch (error) {
       console.error("Error fetching run:", error);
       res.status(500).json({ error: "Failed to fetch run" });
+    }
+  });
+
+  // Deterministically reconstruct a run's model calls from captured artifacts,
+  // with zero API spend (issue #12, Phase 1). Returns the recorded outputs
+  // ordered by step. Requires the run to have been recorded with
+  // RUN_ARTIFACTS_CAPTURE=1; otherwise the artifact list is empty.
+  app.get("/api/runs/:id/replay", async (req, res) => {
+    try {
+      const run = await storage.getRun(req.params.id);
+      if (!run) {
+        return res.status(404).json({ error: "Run not found" });
+      }
+      const artifacts = await replayRun(
+        { getByRun: (id) => storage.getRunArtifactsByRun(id) },
+        req.params.id,
+      );
+      res.json({ runId: req.params.id, artifactCount: artifacts.length, artifacts });
+    } catch (error) {
+      console.error("Error replaying run:", error);
+      res.status(500).json({ error: "Failed to replay run" });
     }
   });
 
@@ -2742,17 +2819,6 @@ You may optionally add brief reasoning after your move on a new line.`;
     return gameConfig.payoffMatrix[key as keyof typeof gameConfig.payoffMatrix];
   }
 
-  async function callPlayer(chatbot: typeof player1, messages: { role: string; content: string }[]): Promise<AICallResult> {
-    switch (chatbot.provider) {
-      case "openai": return callOpenAI(chatbot.model, messages);
-      case "anthropic": return callAnthropic(chatbot.model, messages);
-      case "gemini": return callGemini(chatbot.model, messages);
-      case "xai": return callXAI(chatbot.model, messages);
-      case "openrouter": return callOpenRouter(chatbot.model, messages);
-      default: throw new Error(`Unknown provider: ${chatbot.provider}`);
-    }
-  }
-
   try {
     await storage.updateArenaMatch(matchId, { status: "running" });
 
@@ -2780,7 +2846,7 @@ You may optionally add brief reasoning after your move on a new line.`;
 
       const timedCall = async (chatbot: typeof player1, history: { role: string; content: string }[]) => {
         const start = Date.now();
-        const result = await callPlayer(chatbot, history);
+        const result = await runModel(chatbot.provider, chatbot.model, history, { chatbotId: chatbot.id });
         return { ...result, latencyMs: Date.now() - start };
       };
 
@@ -2860,17 +2926,6 @@ async function runWargame(gameId: string, config: {
 }) {
   const alphaBot = availableChatbots.find(c => c.id === config.alphaModelId)!;
   const betaBot = availableChatbots.find(c => c.id === config.betaModelId)!;
-
-  async function callModel(chatbot: typeof alphaBot, messages: { role: string; content: string }[]): Promise<AICallResult> {
-    switch (chatbot.provider) {
-      case "openai": return callOpenAI(chatbot.model, messages);
-      case "anthropic": return callAnthropic(chatbot.model, messages);
-      case "gemini": return callGemini(chatbot.model, messages);
-      case "xai": return callXAI(chatbot.model, messages);
-      case "openrouter": return callOpenRouter(chatbot.model, messages);
-      default: throw new Error(`Unknown provider: ${chatbot.provider}`);
-    }
-  }
 
   function extractPublicSignal(response: string): string {
     const patterns = [
@@ -2997,7 +3052,7 @@ Format your response with clear headers. Use verbal descriptions of escalation l
       const safeModelCall = async (chatbot: typeof alphaBot, history: { role: string; content: string }[]) => {
         const start = Date.now();
         try {
-          const result = await callModel(chatbot, history);
+          const result = await runModel(chatbot.provider, chatbot.model, history, { chatbotId: chatbot.id });
           return { content: result.content, latencyMs: Date.now() - start, error: undefined };
         } catch (err) {
           return {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,4 +1,6 @@
 import { type Session, type Run, type Chatbot, type InsertSession, type InsertRun, type ChatbotResponse, type ArenaMatch, type ArenaRound, type InsertArenaMatch, type ToolkitItem, type InsertToolkitItem, type LeaderboardEntry, type InsertLeaderboardEntry, type ToolkitLeaderboardEntry, type Epoch, type Joke, type InsertJoke, type JokeRating, type InsertJokeRating, type BenchmarkProposal, type InsertBenchmarkProposal, type BenchmarkWeight, type Construct, type InsertConstruct, type PhysioDataPoint, type InsertPhysioBatch, type Wargame, type WargameTurn, type InsertWargame, type NewsletterSubscriber, type InsertNewsletterSubscriber, type StoryRecipient, type InsertStoryRecipient, type LoginEvent, type InsertLoginEvent, sessions, runs, arenaMatches, wargames, toolkitItems, leaderboardEntries, toolkitLeaderboard, epochs, jokes, jokeRatings, benchmarkProposals, benchmarkWeights, constructs, physioData, newsletterSubscribers, storyRecipients, loginEvents } from "@shared/schema";
+import { runArtifacts } from "@shared/schema";
+import type { RunArtifact } from "./modelClient";
 import { randomUUID } from "crypto";
 import { db } from "./db";
 import { eq, desc, and, sql, ilike, count, inArray, gte, lt } from "drizzle-orm";
@@ -195,6 +197,24 @@ function dbRunToRun(row: typeof runs.$inferSelect): Run {
     startedAt: row.startedAt.toISOString(),
     completedAt: row.completedAt?.toISOString(),
     responses: row.responses || [],
+  };
+}
+
+function dbArtifactToArtifact(row: typeof runArtifacts.$inferSelect): RunArtifact {
+  return {
+    requestHash: row.requestHash,
+    provider: row.provider,
+    model: row.model,
+    request: row.request,
+    content: row.content,
+    usage: row.usage ?? undefined,
+    latencyMs: row.latencyMs,
+    runId: row.runId ?? undefined,
+    chatbotId: row.chatbotId ?? undefined,
+    stepOrder: row.stepOrder ?? undefined,
+    modelVersion: row.modelVersion ?? undefined,
+    finishReason: row.finishReason ?? undefined,
+    responseRaw: row.responseRaw ?? undefined,
   };
 }
 
@@ -425,6 +445,41 @@ export class DatabaseStorage implements IStorage {
 
   async deleteRun(id: string): Promise<void> {
     await db.delete(runs).where(eq(runs.id, id));
+  }
+
+  // --- Run artifacts (record/replay, issue #12) ---
+
+  async createRunArtifact(artifact: RunArtifact): Promise<void> {
+    await db.insert(runArtifacts).values({
+      id: randomUUID(),
+      requestHash: artifact.requestHash,
+      runId: artifact.runId ?? null,
+      chatbotId: artifact.chatbotId ?? null,
+      stepOrder: artifact.stepOrder ?? null,
+      provider: artifact.provider,
+      model: artifact.model,
+      modelVersion: artifact.modelVersion ?? null,
+      request: artifact.request,
+      content: artifact.content,
+      finishReason: artifact.finishReason ?? null,
+      responseRaw: artifact.responseRaw ?? null,
+      usage: artifact.usage ?? null,
+      latencyMs: artifact.latencyMs,
+    });
+  }
+
+  async getRunArtifactByHash(requestHash: string): Promise<RunArtifact | undefined> {
+    const result = await db.select().from(runArtifacts)
+      .where(eq(runArtifacts.requestHash, requestHash))
+      .orderBy(desc(runArtifacts.createdAt))
+      .limit(1);
+    return result[0] ? dbArtifactToArtifact(result[0]) : undefined;
+  }
+
+  async getRunArtifactsByRun(runId: string): Promise<RunArtifact[]> {
+    const result = await db.select().from(runArtifacts)
+      .where(eq(runArtifacts.runId, runId));
+    return result.map(dbArtifactToArtifact);
   }
 
   async getChatbots(): Promise<Chatbot[]> {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { pgTable, varchar, text, timestamp, jsonb, integer } from "drizzle-orm/pg-core";
+import { pgTable, varchar, text, timestamp, jsonb, integer, index } from "drizzle-orm/pg-core";
 
 // Database tables
 export const sessions = pgTable("sessions", {
@@ -44,6 +44,45 @@ export const runs = pgTable("runs", {
     totalTokens?: number;
   }[]>(),
 });
+
+// Run artifacts - content-addressable record of each model call, for
+// deterministic record/replay (issue #12, Phase 1). `requestHash` keys the
+// replay cache; `runId`/`stepOrder` (nullable) link an artifact to a run so
+// replayRun() can reconstruct the call sequence. Artifacts captured without a
+// run context (runId null) still serve as a global replay cache.
+export const runArtifacts = pgTable("run_artifacts", {
+  id: varchar("id").primaryKey(),
+  requestHash: varchar("request_hash").notNull(),
+  runId: varchar("run_id"),
+  chatbotId: varchar("chatbot_id"),
+  stepOrder: integer("step_order"),
+  provider: varchar("provider").notNull(),
+  model: varchar("model").notNull(),
+  // Snapshot the API actually served, when the provider returns it. Lets a
+  // later run detect server-side model drift ("trust over time").
+  modelVersion: varchar("model_version"),
+  request: jsonb("request").notNull().$type<{
+    provider: string;
+    model: string;
+    messages: { role: string; content: string }[];
+    params?: Record<string, unknown>;
+  }>(),
+  content: text("content").notNull(),
+  finishReason: varchar("finish_reason"),
+  // Unparsed provider payload, so parsing can be re-run from raw if the parser
+  // changes — not just from the extracted `content`.
+  responseRaw: jsonb("response_raw"),
+  usage: jsonb("usage").$type<{
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  }>(),
+  latencyMs: integer("latency_ms").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+}, (table) => ({
+  requestHashIdx: index("run_artifacts_request_hash_idx").on(table.requestHash),
+  runIdIdx: index("run_artifacts_run_id_idx").on(table.runId),
+}));
 
 // Arena matches table - for AI vs AI games
 export const arenaMatches = pgTable("arena_matches", {
@@ -230,10 +269,14 @@ export interface TokenUsage {
   totalTokens: number;
 }
 
-// AI call result with content and optional token usage
+// AI call result with content and optional token usage. The optional fields
+// carry provenance for run artifacts (issue #12); orchestration ignores them.
 export interface AICallResult {
   content: string;
   usage?: TokenUsage;
+  modelVersion?: string;
+  finishReason?: string;
+  raw?: unknown;
 }
 
 // A run targeting multiple chatbots


### PR DESCRIPTION
## Phase 1 (Layer A): deterministic record/replay

Implements the run-level record/replay layer from #12 — the **Layer A** half (Layer B / statistical delta stays for a follow-up, as phased in the issue).

### What this does
Every vendor model call now goes through a single `runModel()` dispatcher backed by a thin `ModelClient` with two modes:
- **live** — call the API, and (when recording) persist a `run_artifact`;
- **replay** — resolve by `requestHash`, return the recorded response, **no network**.

Captured artifacts make parsing/scoring re-runnable offline, deterministically, with zero API spend — so an old run can be re-scored after a parser change with no model calls.

### Shape (follows the spec in #12)
- **`shared/schema.ts`** — `run_artifacts`: `requestHash`, `runId`, `chatbotId`, `stepOrder`, `provider`, `model`, `modelVersion`, `request {messages, params}`, `content`, `finishReason`, `response_raw`, `usage`, `latencyMs`, `createdAt` (+ indexes on `request_hash`, `run_id`).
- **`server/modelClient.ts`** — the engine: `computeRequestHash` (stable hash of `{provider, model, messages, params}`), `ModelClient` (live/replay; capture is **fail-safe** — a store error never breaks the model path), and `replayRun(runId)`. Store-agnostic and provider-agnostic, so it unit-tests with no DB and no keys.
- **`server/storage.ts`** — `createRunArtifact` / `getRunArtifactByHash` / `getRunArtifactsByRun`.
- **`server/routes.ts`** — one `runModel()` dispatcher that collapses the four duplicated provider switches (eval / run / arena / wargame); `GET /api/runs/:id/replay` returns a run's recorded calls in order.

### Behind a flag, no behavior change
With no env set: `live` mode, capture **off** → existing runs are byte-for-byte unchanged (just an extra hash). Opt in:
- `RUN_ARTIFACTS_CAPTURE=1` — record artifacts;
- `MODEL_CLIENT_MODE=replay` — serve recorded responses, no API.

The main session loop threads a per-run step index so `replayRun` reconstructs call order. (Arena/wargame calls are recorded as a global hash cache for now; per-match replay can come with Layer B.)

### Notes
- Two representational choices vs the spec sketch: token usage is one nested `usage` object rather than three flat columns (trivially changeable if you'd prefer flat); `response_raw` is only written when `RUN_ARTIFACTS_CAPTURE=1`, so normal runs don't pay the storage.
- **Tests:** the vitest setup is its own PR per your split in #13. I've run the `ModelClient` unit tests locally — hashing/canonicalization, live vs replay, fail-safe capture, replay-miss, ordering, and provenance capture — all green; they land in #13.
- `db:push` creates the new table; no migration of existing data.

If it's easier to land this together with the tests as a single PR, say the word and I'll combine.

---
*Disclosure: human–AI pair — I work with Lor, my Claude Code partner; we read, run, and own everything we submit.*