### PR TITLE
Add vitest; cover record/replay core and /api/history (#13)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsx script/build.ts",
     "start": "NODE_ENV=production node dist/index.cjs",
     "check": "tsc",
+    "test": "vitest run",
     "db:push": "drizzle-kit push"
   },
   "dependencies": {
@@ -109,7 +110,8 @@
     "tailwindcss": "^3.4.17",
     "tsx": "^4.20.5",
     "typescript": "5.6.3",
-    "vite": "^7.3.0"
+    "vite": "^7.3.0",
+    "vitest": "^3.2.6"
   },
   "overrides": {
     "drizzle-kit": {

--- a/server/historyQuery.test.ts
+++ b/server/historyQuery.test.ts
@@ -1,0 +1,56 @@
+// Unit tests for the GET /api/history query/response helpers (issue #13 item 3).
+// Pure functions — no DB, no Express.
+
+import { describe, it, expect } from "vitest";
+import { parseHistoryQuery, buildHistoryResponse } from "./historyQuery";
+
+describe("parseHistoryQuery", () => {
+  it("applies defaults when nothing is supplied", () => {
+    expect(parseHistoryQuery({})).toEqual({ page: 1, limit: 50, search: undefined });
+  });
+
+  it("parses a valid page and limit", () => {
+    expect(parseHistoryQuery({ page: "3", limit: "100" })).toMatchObject({ page: 3, limit: 100 });
+  });
+
+  it("falls back to defaults on non-numeric input", () => {
+    expect(parseHistoryQuery({ page: "abc", limit: "xyz" })).toMatchObject({ page: 1, limit: 50 });
+  });
+
+  it("clamps page to a minimum of 1", () => {
+    expect(parseHistoryQuery({ page: "0" }).page).toBe(1);
+    expect(parseHistoryQuery({ page: "-5" }).page).toBe(1);
+  });
+
+  it("clamps limit to [1, 500]", () => {
+    expect(parseHistoryQuery({ limit: "0" }).limit).toBe(1);
+    expect(parseHistoryQuery({ limit: "9999" }).limit).toBe(500);
+    expect(parseHistoryQuery({ limit: "250" }).limit).toBe(250);
+  });
+
+  it("treats blank / whitespace search as no search", () => {
+    expect(parseHistoryQuery({ search: "" }).search).toBeUndefined();
+    expect(parseHistoryQuery({ search: "   " }).search).toBeUndefined();
+    expect(parseHistoryQuery({ search: 123 }).search).toBeUndefined();
+  });
+
+  it("trims a real search term", () => {
+    expect(parseHistoryQuery({ search: "  prisoner  " }).search).toBe("prisoner");
+  });
+});
+
+describe("buildHistoryResponse", () => {
+  it("passes items/total through and echoes page/limit", () => {
+    const out = buildHistoryResponse({ items: [{ id: "r1" }], total: 1 }, 2, 25);
+    expect(out).toMatchObject({ items: [{ id: "r1" }], total: 1, page: 2, limit: 25 });
+  });
+
+  it("computes totalPages by ceiling division", () => {
+    expect(buildHistoryResponse({ items: [], total: 10 }, 1, 3).totalPages).toBe(4);
+    expect(buildHistoryResponse({ items: [], total: 50 }, 1, 50).totalPages).toBe(1);
+  });
+
+  it("reports zero pages for an empty result set", () => {
+    expect(buildHistoryResponse({ items: [], total: 0 }, 1, 50).totalPages).toBe(0);
+  });
+});

--- a/server/historyQuery.ts
+++ b/server/historyQuery.ts
@@ -1,0 +1,55 @@
+// Pure query/response helpers for GET /api/history, extracted from routes.ts so
+// the parameter normalization and response shaping can be unit-tested without a
+// database or Express (issue #13, item 3). Behaviour is identical to the prior
+// inline logic — this is a refactor, not a behaviour change.
+
+export interface HistoryQueryParams {
+  page: number;
+  limit: number;
+  search?: string;
+}
+
+export const HISTORY_DEFAULT_LIMIT = 50;
+export const HISTORY_MAX_LIMIT = 500;
+
+// Normalize raw request query params into a safe { page, limit, search }:
+//   page  — >= 1, defaults to 1 (NaN / out-of-range -> 1)
+//   limit — clamped to [1, 500], defaults to 50
+//   search — trimmed non-empty string, otherwise undefined
+export function parseHistoryQuery(query: {
+  page?: unknown;
+  limit?: unknown;
+  search?: unknown;
+}): HistoryQueryParams {
+  const rawPage = parseInt(String(query.page || "1"), 10);
+  const rawLimit = parseInt(String(query.limit || String(HISTORY_DEFAULT_LIMIT)), 10);
+  const page = isNaN(rawPage) ? 1 : Math.max(1, rawPage);
+  const limit = isNaN(rawLimit)
+    ? HISTORY_DEFAULT_LIMIT
+    : Math.min(HISTORY_MAX_LIMIT, Math.max(1, rawLimit));
+  const search =
+    typeof query.search === "string" && query.search.trim()
+      ? query.search.trim()
+      : undefined;
+  return { page, limit, search };
+}
+
+export interface HistoryResult<T> {
+  items: T[];
+  total: number;
+}
+
+// Shape the paginated response exactly as the route returned it before.
+export function buildHistoryResponse<T>(
+  result: HistoryResult<T>,
+  page: number,
+  limit: number,
+): HistoryResult<T> & { page: number; limit: number; totalPages: number } {
+  return {
+    items: result.items,
+    total: result.total,
+    page,
+    limit,
+    totalPages: Math.ceil(result.total / limit),
+  };
+}

--- a/server/modelClient.test.ts
+++ b/server/modelClient.test.ts
@@ -1,0 +1,221 @@
+// Unit tests for the deterministic record/replay layer (issue #12 / #13 item 4).
+//
+// Everything here runs with no database and no API keys: the ArtifactStore is an
+// in-memory map and the "vendor call" is a stub. That is the whole point of the
+// Phase-1 design — the model path is store-agnostic and provider-agnostic, so the
+// scoring/replay behaviour can be pinned down deterministically.
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  ModelClient,
+  ReplayMissError,
+  computeRequestHash,
+  replayRun,
+  type ArtifactStore,
+  type ModelRequest,
+  type ModelResult,
+  type RunArtifact,
+} from "./modelClient";
+
+// Minimal in-memory ArtifactStore (also satisfies replayRun's getByRun shape).
+class MemArtifactStore implements ArtifactStore {
+  private byHash = new Map<string, RunArtifact>();
+  private byRun = new Map<string, RunArtifact[]>();
+
+  async getByHash(requestHash: string): Promise<RunArtifact | undefined> {
+    return this.byHash.get(requestHash);
+  }
+  async put(artifact: RunArtifact): Promise<void> {
+    this.byHash.set(artifact.requestHash, artifact);
+    if (artifact.runId) {
+      const list = this.byRun.get(artifact.runId) ?? [];
+      list.push(artifact);
+      this.byRun.set(artifact.runId, list);
+    }
+  }
+  async getByRun(runId: string): Promise<RunArtifact[]> {
+    return this.byRun.get(runId) ?? [];
+  }
+}
+
+const baseRequest = (): ModelRequest => ({
+  provider: "anthropic",
+  model: "claude-sonnet-4-6",
+  messages: [{ role: "user", content: "Cooperate or defect?" }],
+  params: { temperature: 0, max_tokens: 256 },
+});
+
+const baseResult = (): ModelResult => ({
+  content: "COOPERATE",
+  usage: { promptTokens: 10, completionTokens: 1, totalTokens: 11 },
+  modelVersion: "claude-sonnet-4-6-20260101",
+  finishReason: "stop",
+  raw: { id: "msg_123", stop_reason: "end_turn" },
+});
+
+describe("computeRequestHash", () => {
+  it("is stable for an identical request", () => {
+    expect(computeRequestHash(baseRequest())).toBe(
+      computeRequestHash(baseRequest()),
+    );
+  });
+
+  it("is independent of param key order (stable stringify)", () => {
+    const a: ModelRequest = { ...baseRequest(), params: { temperature: 0, max_tokens: 256 } };
+    const b: ModelRequest = { ...baseRequest(), params: { max_tokens: 256, temperature: 0 } };
+    expect(computeRequestHash(a)).toBe(computeRequestHash(b));
+  });
+
+  it("treats missing params and empty params as the same", () => {
+    const a: ModelRequest = { ...baseRequest(), params: undefined };
+    const b: ModelRequest = { ...baseRequest(), params: {} };
+    expect(computeRequestHash(a)).toBe(computeRequestHash(b));
+  });
+
+  it("changes when provider, model, messages, or params change", () => {
+    const h = computeRequestHash(baseRequest());
+    expect(computeRequestHash({ ...baseRequest(), provider: "openai" })).not.toBe(h);
+    expect(computeRequestHash({ ...baseRequest(), model: "gpt-4o" })).not.toBe(h);
+    expect(
+      computeRequestHash({ ...baseRequest(), messages: [{ role: "user", content: "different" }] }),
+    ).not.toBe(h);
+    expect(
+      computeRequestHash({ ...baseRequest(), params: { temperature: 1 } }),
+    ).not.toBe(h);
+  });
+
+  it("is sensitive to message order", () => {
+    const a: ModelRequest = {
+      ...baseRequest(),
+      messages: [
+        { role: "system", content: "be terse" },
+        { role: "user", content: "hi" },
+      ],
+    };
+    const b: ModelRequest = { ...baseRequest(), messages: [...a.messages].reverse() };
+    expect(computeRequestHash(a)).not.toBe(computeRequestHash(b));
+  });
+});
+
+describe("ModelClient live mode", () => {
+  it("calls the vendor and does NOT persist when capture is off (default)", async () => {
+    const store = new MemArtifactStore();
+    const putSpy = vi.spyOn(store, "put");
+    const client = new ModelClient(store); // defaults: live, capture off
+    const liveCall = vi.fn(async () => baseResult());
+
+    const result = await client.complete(baseRequest(), liveCall);
+
+    expect(liveCall).toHaveBeenCalledOnce();
+    expect(result.content).toBe("COOPERATE");
+    expect(putSpy).not.toHaveBeenCalled();
+  });
+
+  it("persists a fully-provenanced artifact when capture is on", async () => {
+    const store = new MemArtifactStore();
+    // Deterministic clock: two reads 42ms apart -> latencyMs === 42.
+    const now = vi.fn().mockReturnValueOnce(1000).mockReturnValueOnce(1042);
+    const client = new ModelClient(store, { capture: true, now });
+
+    await client.complete(baseRequest(), async () => baseResult(), {
+      runId: "run-1",
+      chatbotId: "bot-a",
+      stepOrder: 3,
+    });
+
+    const stored = await store.getByHash(computeRequestHash(baseRequest()));
+    expect(stored).toBeDefined();
+    // Every spec'd provenance field must survive capture (the artifact is a contract).
+    expect(stored).toMatchObject({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      content: "COOPERATE",
+      latencyMs: 42,
+      runId: "run-1",
+      chatbotId: "bot-a",
+      stepOrder: 3,
+      modelVersion: "claude-sonnet-4-6-20260101",
+      finishReason: "stop",
+      responseRaw: { id: "msg_123", stop_reason: "end_turn" },
+    });
+    expect(stored!.request).toEqual(baseRequest());
+    expect(stored!.usage).toEqual({ promptTokens: 10, completionTokens: 1, totalTokens: 11 });
+  });
+
+  it("is fail-safe: a store error never breaks the model path", async () => {
+    const store = new MemArtifactStore();
+    vi.spyOn(store, "put").mockRejectedValue(new Error("disk full"));
+    const logger = vi.fn();
+    const client = new ModelClient(store, { capture: true, logger });
+
+    const result = await client.complete(baseRequest(), async () => baseResult());
+
+    expect(result.content).toBe("COOPERATE"); // run still succeeds
+    expect(logger).toHaveBeenCalledOnce();
+    expect(logger.mock.calls[0][0]).toContain("failed to capture artifact");
+  });
+});
+
+describe("ModelClient replay mode", () => {
+  it("returns the stored response and never calls the vendor", async () => {
+    const store = new MemArtifactStore();
+    // Record once...
+    const recorder = new ModelClient(store, { capture: true });
+    await recorder.complete(baseRequest(), async () => baseResult());
+
+    // ...then replay with a liveCall that would fail if invoked.
+    const replayer = new ModelClient(store, { mode: "replay" });
+    const liveCall = vi.fn(async () => {
+      throw new Error("network must not be touched in replay");
+    });
+
+    const result = await replayer.complete(baseRequest(), liveCall);
+
+    expect(liveCall).not.toHaveBeenCalled();
+    expect(result.content).toBe("COOPERATE");
+    expect(result.usage).toEqual({ promptTokens: 10, completionTokens: 1, totalTokens: 11 });
+  });
+
+  it("throws ReplayMissError (loudly) on an unrecorded request", async () => {
+    const store = new MemArtifactStore();
+    const replayer = new ModelClient(store, { mode: "replay" });
+    const hash = computeRequestHash(baseRequest());
+
+    await expect(
+      replayer.complete(baseRequest(), async () => baseResult()),
+    ).rejects.toBeInstanceOf(ReplayMissError);
+    await expect(
+      replayer.complete(baseRequest(), async () => baseResult()),
+    ).rejects.toMatchObject({ requestHash: hash });
+  });
+});
+
+describe("replayRun (deterministic eval-run from artifacts)", () => {
+  it("reconstructs a recorded run's calls in step order with zero API spend", async () => {
+    const store = new MemArtifactStore();
+    const liveCalls = vi.fn();
+
+    // Fixture: a real two-player prisoner's-dilemma run, captured out of order.
+    const fixture: RunArtifact[] = [
+      { requestHash: "h-b", provider: "openai", model: "gpt-4o", request: baseRequest(), content: "DEFECT", latencyMs: 5, runId: "run-42", stepOrder: 2 },
+      { requestHash: "h-a", provider: "anthropic", model: "claude-sonnet-4-6", request: baseRequest(), content: "COOPERATE", latencyMs: 7, runId: "run-42", stepOrder: 1 },
+    ];
+    for (const a of fixture) await store.put(a);
+
+    const replayed = await replayRun(store, "run-42");
+
+    // Ordered by step, no live calls — the eval's model outputs are now testable.
+    expect(liveCalls).not.toHaveBeenCalled();
+    expect(replayed.map((a) => a.stepOrder)).toEqual([1, 2]);
+    expect(replayed.map((a) => a.content)).toEqual(["COOPERATE", "DEFECT"]);
+
+    // A deterministic scoring pass over the replayed transcript is now reproducible.
+    const cooperated = replayed.filter((a) => a.content === "COOPERATE").length;
+    expect(cooperated).toBe(1);
+  });
+
+  it("returns an empty transcript for an unknown run", async () => {
+    const store = new MemArtifactStore();
+    expect(await replayRun(store, "nope")).toEqual([]);
+  });
+});

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -15,6 +15,7 @@ import cron from "node-cron";
 import { ESCALATION_LADDER, scenarioConfigs, escalationBeats } from "./wargameConfig";
 import { ModelClient, replayRun, type ArtifactStore, type ModelCallContext } from "./modelClient";
 import { deriveEthicalSpace } from "@shared/ethicalSpace";
+import { parseHistoryQuery, buildHistoryResponse } from "./historyQuery";
 
 // Read app version from package.json once at startup
 let APP_VERSION = "1.0.0";
@@ -1494,19 +1495,9 @@ export async function registerRoutes(
   // Get history (runs with sessions)
   app.get("/api/history", async (req, res) => {
     try {
-      const rawPage = parseInt(String(req.query.page || "1"), 10);
-      const rawLimit = parseInt(String(req.query.limit || "50"), 10);
-      const page = isNaN(rawPage) ? 1 : Math.max(1, rawPage);
-      const limit = isNaN(rawLimit) ? 50 : Math.min(500, Math.max(1, rawLimit));
-      const search = typeof req.query.search === "string" && req.query.search.trim() ? req.query.search.trim() : undefined;
+      const { page, limit, search } = parseHistoryQuery(req.query);
       const result = await storage.getRunsHistory({ page, limit, search });
-      res.json({
-        items: result.items,
-        total: result.total,
-        page,
-        limit,
-        totalPages: Math.ceil(result.total / limit),
-      });
+      res.json(buildHistoryResponse(result, page, limit));
     } catch (error) {
       console.error("Error fetching history:", error);
       res.status(500).json({ error: "Failed to fetch history" });

--- a/server/storage.history.test.ts
+++ b/server/storage.history.test.ts
@@ -1,0 +1,88 @@
+// Integration test for storage.getRunsHistory (issue #13, item 2).
+//
+// This one needs a real Postgres: getRunsHistory is a thin Drizzle query
+// (ilike on session title + pagination over runs), so the honest way to pin it
+// down is to run it against the actual database rather than a mock. It is gated
+// on DATABASE_URL, so a DB-less `npm test` simply skips it.
+//
+// Run it with a Postgres pointed at by DATABASE_URL and the schema pushed
+// (`npm run db:push`), e.g.:
+//   DATABASE_URL=postgresql://user:pass@127.0.0.1:5432/coe_test npm test
+
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { sql } from "drizzle-orm";
+import { storage } from "./storage";
+import { db } from "./db";
+import { sessions, runs } from "@shared/schema";
+
+const hasDb = !!process.env.DATABASE_URL;
+
+async function seedSession(id: string, title: string, runCount: number) {
+  await db.insert(sessions).values({
+    id,
+    title,
+    prompts: [{ id: "p1", order: 0, role: "user", content: "hi" }],
+  });
+  for (let i = 0; i < runCount; i++) {
+    await db.insert(runs).values({
+      id: `${id}-run-${i}`,
+      sessionId: id,
+      chatbotIds: ["bot-a"],
+      status: "completed",
+      // Distinct timestamps so the desc() ordering is well-defined.
+      startedAt: new Date(Date.UTC(2026, 0, 1, 0, 0, i)),
+      responses: [{ chatbotId: "bot-a", stepOrder: 0, content: "COOPERATE", latencyMs: 5 }],
+    });
+  }
+}
+
+describe.skipIf(!hasDb)("getRunsHistory (integration, real Postgres)", () => {
+  beforeEach(async () => {
+    await db.execute(sql`TRUNCATE TABLE runs, sessions RESTART IDENTITY CASCADE`);
+  });
+
+  afterAll(async () => {
+    // Release the pool so vitest can exit cleanly.
+    await (db.$client as { end?: () => Promise<void> }).end?.();
+  });
+
+  it("returns every run when no search is given", async () => {
+    await seedSession("s1", "Prisoner's Dilemma", 2);
+    await seedSession("s2", "Life Raft", 1);
+
+    const res = await storage.getRunsHistory({ page: 1, limit: 50 });
+
+    expect(res.total).toBe(3);
+    expect(res.items).toHaveLength(3);
+  });
+
+  it("filters by case-insensitive title substring (ilike)", async () => {
+    await seedSession("s1", "Prisoner's Dilemma", 2);
+    await seedSession("s2", "Life Raft", 1);
+
+    const res = await storage.getRunsHistory({ page: 1, limit: 50, search: "prisoner" });
+
+    expect(res.total).toBe(2);
+    expect(res.items.every((i) => i.session.title === "Prisoner's Dilemma")).toBe(true);
+  });
+
+  it("returns an empty result for a non-matching search", async () => {
+    await seedSession("s1", "Prisoner's Dilemma", 1);
+
+    const res = await storage.getRunsHistory({ page: 1, limit: 50, search: "zzz-nomatch" });
+
+    expect(res).toEqual({ items: [], total: 0 });
+  });
+
+  it("paginates: total counts all matches, items only the requested page", async () => {
+    await seedSession("s1", "Prisoner's Dilemma", 5);
+
+    const page1 = await storage.getRunsHistory({ page: 1, limit: 2 });
+    expect(page1.total).toBe(5);
+    expect(page1.items).toHaveLength(2);
+
+    const page3 = await storage.getRunsHistory({ page: 3, limit: 2 });
+    expect(page3.total).toBe(5);
+    expect(page3.items).toHaveLength(1); // 5 rows, third page of size 2 -> 1 left
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "url";
+
+// Server-side tests run in a plain Node environment. The pure tests need no DB
+// and no API keys; the getRunsHistory integration test additionally needs a
+// Postgres via DATABASE_URL (it self-skips when that is absent). Client/React
+// tests are out of scope here.
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@shared": fileURLToPath(new URL("./shared", import.meta.url)),
+    },
+  },
+  test: {
+    include: ["server/**/*.test.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
Closes the testing thread. vitest wired in; 26 tests.

- `modelClient.test.ts` — record/replay core, no DB and no keys: request-hash stability + sensitivity, capture persists every provenance field, capture is fail-safe (a store error never breaks a run), replay returns the recorded response and never hits the network, replay miss throws.
- `replayRun` — reconstructs a run's calls in step order from artifacts, zero API. The deterministic eval-run (item 4) that the #14 seam unblocked.
- `historyQuery.ts` — pulled the `/api/history` param parsing + response shaping out of routes.ts into pure functions and covered them (page/limit clamp, blank search, totalPages). routes.ts calls them; behaviour identical.
- `storage.history.test.ts` — getRunsHistory against real Postgres: empty search, ilike substring match/no-match, pagination. Gated on DATABASE_URL, skips without it.

Verify: `npm test` → 22 passed; with DATABASE_URL set, 26 (the 4 storage tests run against Postgres). tsc error count unchanged (no net-new). Diff is package.json (+test script, +vitest) and routes.ts (inline → helpers); lockfile left untouched — it's pinned to the Replit registry mirror, so regenerate it in your env.
