### PR TITLE
Add HELM-style Stat + MetricName metric primitives (#20)

### DIFF
--- a/shared/metrics.test.ts
+++ b/shared/metrics.test.ts
@@ -1,0 +1,88 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  type MetricName,
+  metricKey,
+  emptyStat,
+  addToStat,
+  aggregateStat,
+  mergeStats,
+} from "./metrics.ts";
+
+const near = (a: number, b: number, eps = 1e-9) =>
+  assert.ok(Math.abs(a - b) < eps, `expected ${a} ≈ ${b}`);
+
+test("metricKey is stable regardless of context insertion order", () => {
+  const a: MetricName = {
+    name: "cooperation_rate",
+    split: "pre-prompt",
+    context: { tier: "frontier", category: "deception" },
+  };
+  const b: MetricName = {
+    name: "cooperation_rate",
+    split: "pre-prompt",
+    context: { category: "deception", tier: "frontier" },
+  };
+  assert.equal(metricKey(a), metricKey(b));
+  assert.equal(
+    metricKey(a),
+    "cooperation_rate|split=pre-prompt|ctx=category=deception,tier=frontier",
+  );
+});
+
+test("metricKey emits only the axes that are present", () => {
+  assert.equal(metricKey({ name: "coop" }), "coop");
+  assert.equal(metricKey({ name: "coop", subSplit: "x" }), "coop|sub=x");
+});
+
+test("distinct conditions produce distinct keys", () => {
+  const base: MetricName = { name: "coop", context: { tier: "frontier" } };
+  const other: MetricName = { name: "coop", context: { tier: "small" } };
+  assert.notEqual(metricKey(base), metricKey(other));
+});
+
+test("aggregateStat computes the distribution (population stddev, HELM)", () => {
+  const name: MetricName = { name: "cooperation_rate" };
+  const s = aggregateStat(name, [0, 1, 1, 0, 1]);
+  assert.equal(s.count, 5);
+  assert.equal(s.sum, 3);
+  assert.equal(s.min, 0);
+  assert.equal(s.max, 1);
+  near(s.mean, 0.6);
+  near(s.variance, 0.24); // 3/5 - 0.6^2
+  near(s.stddev, Math.sqrt(0.24));
+});
+
+test("emptyStat is safe (no NaN on zero observations)", () => {
+  const s = emptyStat({ name: "coop" });
+  assert.equal(s.count, 0);
+  assert.equal(s.mean, 0);
+  assert.equal(s.variance, 0);
+  assert.equal(s.stddev, 0);
+});
+
+test("addToStat does not mutate its input", () => {
+  const a = aggregateStat({ name: "coop" }, [1, 1]);
+  const before = { ...a };
+  addToStat(a, 0);
+  assert.deepEqual(a, before);
+});
+
+test("mergeStats is associative with full aggregation", () => {
+  const name: MetricName = { name: "coop" };
+  const left = aggregateStat(name, [0, 1, 1]);
+  const right = aggregateStat(name, [0, 1]);
+  const merged = mergeStats(left, right);
+  const whole = aggregateStat(name, [0, 1, 1, 0, 1]);
+  near(merged.mean, whole.mean);
+  near(merged.variance, whole.variance);
+  assert.equal(merged.count, whole.count);
+  assert.equal(merged.sum, whole.sum);
+});
+
+test("merging an empty Stat is a no-op", () => {
+  const name: MetricName = { name: "coop" };
+  const s = aggregateStat(name, [1, 0, 1]);
+  assert.deepEqual(mergeStats(emptyStat(name), s), { ...s, name });
+  assert.deepEqual(mergeStats(s, emptyStat(name)), s);
+});

--- a/shared/metrics.ts
+++ b/shared/metrics.ts
@@ -1,0 +1,129 @@
+// HELM-style metric primitives (issue #20).
+//
+// Borrows two shapes from HELM (stanford-crfm/helm) without taking on its
+// harness, so cross-eval comparison gets cheaper:
+//
+//   - MetricName: a *structured*, comparable key instead of a bare string, so
+//     "cooperation_rate" under different conditions (model tier #17, category
+//     #15, pre-prompt vs scenario baseline #18) is a distinct, comparable key
+//     rather than a string you have to parse back apart.
+//
+//   - Stat: a metric stored as a *distribution*, never a single number. Re-run
+//     N times, fold into one Stat, and stddev separates signal from sampling
+//     noise — that is the statistical-delta idea from #12. Stats carry running
+//     sum / sumSquared (HELM's statistic.py shape), so they aggregate online
+//     and merge associatively rather than needing every raw value re-held.
+
+/** A structured, comparable metric key. Mirrors HELM's metric_name.py. */
+export type MetricName = {
+  /** Base metric, e.g. "cooperation_rate". */
+  name: string;
+  /** Primary condition axis, e.g. "pre-prompt" | scenario id (#18 baseline). */
+  split?: string;
+  /** Secondary condition, e.g. category (#15). */
+  subSplit?: string;
+  /** Free context dimensions: model tier (#17), construct, game type, ... */
+  context?: Record<string, string>;
+};
+
+/**
+ * Canonical, stable string for a MetricName. The same structured key always
+ * serializes identically — context entries are sorted by key — so comparing
+ * metrics across runs/evals is a dictionary lookup, not string parsing.
+ *
+ * Format (readable, debuggable):
+ *   name[|split][|sub][|k=v,k=v]
+ * where context pairs are sorted and only present axes are emitted.
+ */
+export function metricKey(name: MetricName): string {
+  const parts: string[] = [name.name];
+  if (name.split !== undefined) parts.push(`split=${name.split}`);
+  if (name.subSplit !== undefined) parts.push(`sub=${name.subSplit}`);
+  if (name.context) {
+    const ctx = Object.keys(name.context)
+      .sort()
+      .map((k) => `${k}=${name.context![k]}`)
+      .join(",");
+    if (ctx) parts.push(`ctx=${ctx}`);
+  }
+  return parts.join("|");
+}
+
+/**
+ * A metric as a distribution. `mean` / `variance` / `stddev` are derived from
+ * the running aggregates; `variance` is the population variance (divide by
+ * count), matching HELM's statistic.py so values line up with their tooling.
+ */
+export type Stat = {
+  name: MetricName;
+  count: number;
+  sum: number;
+  sumSquared: number;
+  min: number;
+  max: number;
+  mean: number;
+  variance: number;
+  stddev: number;
+};
+
+function derive(s: {
+  name: MetricName;
+  count: number;
+  sum: number;
+  sumSquared: number;
+  min: number;
+  max: number;
+}): Stat {
+  const mean = s.count > 0 ? s.sum / s.count : 0;
+  // Population variance (HELM): E[x^2] - E[x]^2, floored at 0 against fp drift.
+  const variance =
+    s.count > 0 ? Math.max(0, s.sumSquared / s.count - mean * mean) : 0;
+  return { ...s, mean, variance, stddev: Math.sqrt(variance) };
+}
+
+/** An empty Stat for `name`, ready to accumulate observations. */
+export function emptyStat(name: MetricName): Stat {
+  return derive({
+    name,
+    count: 0,
+    sum: 0,
+    sumSquared: 0,
+    min: Infinity,
+    max: -Infinity,
+  });
+}
+
+/** Fold one observation into a Stat (returns a new Stat; input untouched). */
+export function addToStat(stat: Stat, value: number): Stat {
+  return derive({
+    name: stat.name,
+    count: stat.count + 1,
+    sum: stat.sum + value,
+    sumSquared: stat.sumSquared + value * value,
+    min: Math.min(stat.min, value),
+    max: Math.max(stat.max, value),
+  });
+}
+
+/** Aggregate raw observations into one Stat keyed by `name`. */
+export function aggregateStat(name: MetricName, values: number[]): Stat {
+  return values.reduce<Stat>(addToStat, emptyStat(name));
+}
+
+/**
+ * Merge two Stats into one. Associative: merging per-shard Stats equals
+ * aggregating all raw values together. Caller is responsible for only merging
+ * Stats with the same metricKey; the merged Stat keeps `a.name`.
+ */
+export function mergeStats(a: Stat, b: Stat): Stat {
+  if (a.count === 0) return { ...b, name: a.name };
+  if (b.count === 0) return a;
+  return derive({
+    name: a.name,
+    count: a.count + b.count,
+    sum: a.sum + b.sum,
+    sumSquared: a.sumSquared + b.sumSquared,
+    min: Math.min(a.min, b.min),
+    max: Math.max(a.max, b.max),
+  });
+}


### PR DESCRIPTION
Borrows two shapes from HELM (stanford-crfm/helm) without its harness, so cross-eval comparison gets cheaper:

- **MetricName** — a structured, comparable key instead of a bare string, so `cooperation_rate` under different conditions (model tier #17, category #15, pre-prompt vs scenario baseline #18) is a distinct comparable key.
- **Stat** — a metric as a distribution (running `sum`/`sumSquared`, HELM's `statistic.py` shape), so stddev across repeated runs separates signal from sampling noise (the statistical-delta idea from #12). Stats aggregate online and merge associatively.

**New:** `shared/metrics.ts` (types + `metricKey` + `emptyStat`/`addToStat`/`aggregateStat`/`mergeStats`), `shared/metrics.test.ts` (8 cases, `node:test`, no new deps).

**Design notes:** population variance to match HELM `statistic.py`; `metricKey` sorts context for stable keys. Scope is types + helpers only; wiring run `responses` into Stats per `(MetricName, condition)` is a focused follow-up.

**Test:** `npx tsx --test shared/metrics.test.ts` → 8 pass. (Repo has pre-existing `tsc` errors in `server/*` unrelated to this change.)
