### PR TITLE
Aggregate metrics across runs + statistical delta (#12)

### DIFF
--- a/shared/metrics.test.ts
+++ b/shared/metrics.test.ts
@@ -7,6 +7,8 @@ import {
   addToStat,
   aggregateStat,
   mergeStats,
+  aggregateByMetric,
+  statDelta,
 } from "./metrics.ts";
 
 const near = (a: number, b: number, eps = 1e-9) =>
@@ -85,4 +87,64 @@ test("merging an empty Stat is a no-op", () => {
   const s = aggregateStat(name, [1, 0, 1]);
   assert.deepEqual(mergeStats(emptyStat(name), s), { ...s, name });
   assert.deepEqual(mergeStats(s, emptyStat(name)), s);
+});
+
+test("aggregateByMetric folds observations into one Stat per key", () => {
+  const frontier: MetricName = { name: "coop", context: { tier: "frontier" } };
+  const small: MetricName = { name: "coop", context: { tier: "small" } };
+  const m = aggregateByMetric([
+    { name: frontier, value: 1 },
+    { name: frontier, value: 0 },
+    { name: small, value: 1 },
+  ]);
+  assert.equal(m.size, 2);
+  const f = m.get(metricKey(frontier))!;
+  assert.equal(f.count, 2);
+  near(f.mean, 0.5);
+  assert.equal(m.get(metricKey(small))!.count, 1);
+});
+
+test("aggregateByMetric keys by condition, not insertion order", () => {
+  const a: MetricName = { name: "coop", context: { tier: "x", cat: "y" } };
+  const b: MetricName = { name: "coop", context: { cat: "y", tier: "x" } };
+  const m = aggregateByMetric([
+    { name: a, value: 1 },
+    { name: b, value: 0 },
+  ]);
+  assert.equal(m.size, 1); // same key despite different context order
+  assert.equal(m.get(metricKey(a))!.count, 2);
+});
+
+test("statDelta flags a real shift as significant", () => {
+  const n: MetricName = { name: "coop" };
+  const a = aggregateStat(n, [0, 0, 0, 0, 0, 0, 0, 1, 0, 0]); // mean 0.1
+  const b = aggregateStat(n, [1, 1, 1, 1, 1, 1, 1, 0, 1, 1]); // mean 0.9
+  const d = statDelta(a, b);
+  near(d.meanDelta, 0.8);
+  assert.ok(d.z > 2 && d.significant);
+});
+
+test("statDelta treats overlapping distributions as noise", () => {
+  const n: MetricName = { name: "coop" };
+  const a = aggregateStat(n, [0, 1, 0, 1, 0]); // mean 0.4
+  const b = aggregateStat(n, [0, 1, 1, 0, 1]); // mean 0.6
+  const d = statDelta(a, b);
+  assert.equal(d.significant, false);
+});
+
+test("statDelta: perfect separation is infinitely significant", () => {
+  const n: MetricName = { name: "coop" };
+  const d = statDelta(aggregateStat(n, [0, 0, 0]), aggregateStat(n, [1, 1, 1]));
+  assert.equal(d.stderr, 0);
+  assert.equal(d.z, Infinity);
+  assert.ok(d.significant);
+});
+
+test("statDelta: no change is not significant", () => {
+  const n: MetricName = { name: "coop" };
+  const s = aggregateStat(n, [0, 1, 0, 1]);
+  const d = statDelta(s, s);
+  assert.equal(d.meanDelta, 0);
+  assert.equal(d.z, 0);
+  assert.equal(d.significant, false);
 });

--- a/shared/metrics.ts
+++ b/shared/metrics.ts
@@ -127,3 +127,55 @@ export function mergeStats(a: Stat, b: Stat): Stat {
     max: Math.max(a.max, b.max),
   });
 }
+
+/**
+ * Fold per-observation values into one Stat per MetricName. Observations that
+ * serialize to the same `metricKey` (same metric under the same condition) are
+ * aggregated together. This is the "many runs -> one Stat per (metric,
+ * condition)" step from #12: until now the schema stored no metric as an
+ * aggregate across runs, only recomputed it from `responses` each time.
+ */
+export function aggregateByMetric(
+  observations: Array<{ name: MetricName; value: number }>,
+): Map<string, Stat> {
+  const out = new Map<string, Stat>();
+  for (const { name, value } of observations) {
+    const key = metricKey(name);
+    out.set(key, addToStat(out.get(key) ?? emptyStat(name), value));
+  }
+  return out;
+}
+
+/**
+ * Signed difference between two Stats of the same metric, with a gate that
+ * separates a real shift from sampling noise (#12's "statistical delta").
+ * `stderr` is the standard error of the difference of means; `z` is the change
+ * in those units; `significant` is true only when |z| clears `threshold`
+ * (default 2, ~95%). Comparing a metric before/after a change (pre-prompt vs
+ * scenario #18, tier A vs tier B #17) reduces to one call.
+ */
+export type StatDelta = {
+  meanDelta: number; // b.mean - a.mean
+  stderr: number;    // standard error of the difference of means
+  z: number;         // meanDelta / stderr (0 when there is no spread)
+  significant: boolean;
+};
+
+export function statDelta(a: Stat, b: Stat, threshold = 2): StatDelta {
+  const meanDelta = b.mean - a.mean;
+  // SE of the difference of two independent sample means: sqrt(varA/nA + varB/nB).
+  const seA = a.count > 0 ? a.variance / a.count : 0;
+  const seB = b.count > 0 ? b.variance / b.count : 0;
+  const stderr = Math.sqrt(seA + seB);
+  // stderr 0 means both groups are perfectly tight: any real mean gap is
+  // infinitely separated from noise; an equal gap of 0 is just no change.
+  const z =
+    stderr > 0
+      ? meanDelta / stderr
+      : meanDelta === 0
+        ? 0
+        : meanDelta > 0
+          ? Infinity
+          : -Infinity;
+  return { meanDelta, stderr, z, significant: Math.abs(z) >= threshold };
+}


### PR DESCRIPTION
Follow-up to #26 (merged): #26 landed the `Stat` + `MetricName` primitives; this adds the aggregation and comparison layer flagged there, which is the second half of #12.

- **`aggregateByMetric(observations)`** -> one `Stat` per `MetricName` key. This is the "many runs -> one Stat per (metric, condition)" step from #12: until now nothing stored a metric as an aggregate across runs, it was recomputed from `responses` each time.
- **`statDelta(a, b)`** -> signed mean difference with a noise gate: `stderr` is the standard error of the difference of means, `z = meanDelta / stderr`, and `significant` is true only when `|z| >= 2` (~95%). That is #12's "statistical delta" made concrete: stddev across repeated runs separates signal from sampling noise. Comparing a metric pre-prompt vs scenario (#18) or across model tiers (#17) is one call.
- Edge handled: perfect separation (zero within-group variance) yields infinite significance rather than a divide-by-zero false negative.

Pure `shared/` helpers, no new deps. `node:test` coverage now 14 cases.

**Test:** `npx tsx --test shared/metrics.test.ts` -> 14 pass.

Next (separate, to keep this reviewable): route `server/routes.ts` per-category scores (prisoner / liferaft / sycophancy / deception / ...) through `aggregateByMetric` so the analysis endpoints return aggregated Stats + deltas instead of recomputing per request.
