### PR TITLE
Model capability tiers for runs (#17)

### DIFF
--- a/shared/modelTier.test.ts
+++ b/shared/modelTier.test.ts
@@ -1,0 +1,65 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { modelTier, statsByTier, type ModelTier } from "./modelTier.ts";
+
+test("modelTier classifies frontier flagships", () => {
+  for (const id of [
+    "openai/gpt-5",
+    "openai/o3",
+    "anthropic/claude-opus-4.8",
+    "google/gemini-3.1-pro",
+    "deepseek/deepseek-r1",
+    "meta/llama-3.1-405b",
+  ]) {
+    assert.equal(modelTier(id), "frontier", id);
+  }
+});
+
+test("modelTier classifies small/cheap variants (size or suffix)", () => {
+  for (const id of [
+    "openai/gpt-5-mini",
+    "google/gemini-3.5-flash",
+    "anthropic/claude-haiku-4.5",
+    "qwen/qwen-2.5-7b",
+    "some/model-lite",
+  ]) {
+    assert.equal(modelTier(id), "small", id);
+  }
+});
+
+test("modelTier falls back to mid, and unknown for empty", () => {
+  assert.equal(modelTier("mistralai/mistral-large-2512"), "mid");
+  assert.equal(modelTier("anthropic/claude-sonnet-4.6"), "mid");
+  assert.equal(modelTier(""), "unknown");
+});
+
+test("overrides win over the heuristic", () => {
+  assert.equal(modelTier("openai/gpt-5", { "openai/gpt-5": "mid" }), "mid");
+  assert.equal(
+    modelTier("house/custom", { "house/custom": "frontier" }),
+    "frontier",
+  );
+});
+
+test("statsByTier shows cooperation dropping below the frontier", () => {
+  const obs = [
+    { model: "anthropic/claude-opus-4.8", value: 1 }, // frontier
+    { model: "openai/gpt-5", value: 1 }, // frontier
+    { model: "mistralai/mistral-large", value: 1 }, // mid
+    { model: "mistralai/mistral-large", value: 0 }, // mid
+    { model: "openai/gpt-5-mini", value: 0 }, // small
+    { model: "anthropic/claude-haiku-4.5", value: 0 }, // small
+  ];
+  const byTier = statsByTier(obs);
+  assert.equal(byTier.get("frontier")!.mean, 1);
+  assert.equal(byTier.get("mid")!.mean, 0.5);
+  assert.equal(byTier.get("small")!.mean, 0);
+  assert.equal(byTier.get("frontier")!.count, 2);
+});
+
+test("statsByTier respects overrides", () => {
+  const ov: Record<string, ModelTier> = { "x/y": "small" };
+  const byTier = statsByTier([{ model: "x/y", value: 0 }], ov);
+  assert.equal(byTier.get("small")!.count, 1);
+  assert.equal(byTier.has("mid"), false);
+});

--- a/shared/modelTier.ts
+++ b/shared/modelTier.ts
@@ -1,0 +1,59 @@
+// Model capability tiers (issue #17).
+//
+// Most runs so far used only frontier models, where everyone cooperates and
+// the interesting variance hides below the frontier. Tagging each run with a
+// coarse tier lets the leaderboard show *where* cooperation breaks down.
+//
+// Tiers are a heuristic on the model id plus an `overrides` escape hatch — they
+// only need to be coarse and consistent, not authoritative. Composes with the
+// metric primitives (#20): use `tier` as MetricName.context.tier, and statDelta
+// (#12) to test whether a drop between tiers is signal or sampling noise.
+
+import { type Stat, emptyStat, addToStat } from "./metrics.ts";
+
+export type ModelTier = "frontier" | "mid" | "small" | "unknown";
+
+export const TIER_ORDER: ModelTier[] = ["small", "mid", "frontier"];
+
+// Small/cheap variants — checked first so "gpt-5-mini" lands in `small`, not
+// `frontier`. Word boundaries keep "mini" from matching inside "gemini"; the
+// size clause matches 1b–13b but not 70b/405b.
+const SMALL =
+  /\b(?:mini|flash|lite|nano|tiny|haiku|small)\b|\b[1-9]b\b|\b1[0-3]b\b/i;
+
+// Flagship/frontier families.
+const FRONTIER =
+  /gpt-5|\bo[1-9]\b|\bopus\b|gemini-[0-9.]*-(?:ultra|pro)|grok-[3-9]|deepseek-(?:v[3-9]|r[1-9])|\b405b\b/i;
+
+/** Classify a model id into a coarse capability tier (heuristic + overrides). */
+export function modelTier(
+  modelId: string,
+  overrides: Record<string, ModelTier> = {},
+): ModelTier {
+  if (modelId in overrides) return overrides[modelId];
+  if (!modelId) return "unknown";
+  const id = modelId.toLowerCase();
+  if (SMALL.test(id)) return "small";
+  if (FRONTIER.test(id)) return "frontier";
+  return "mid";
+}
+
+/**
+ * Bucket per-model metric observations into one Stat per tier, so a single
+ * metric (e.g. cooperation rate) can be read across capability tiers and show
+ * where it breaks down below the frontier (#17). Pair adjacent tiers with
+ * statDelta (#12) to separate a real drop from sampling noise.
+ */
+export function statsByTier(
+  observations: Array<{ model: string; value: number }>,
+  overrides?: Record<string, ModelTier>,
+): Map<ModelTier, Stat> {
+  const out = new Map<ModelTier, Stat>();
+  for (const { model, value } of observations) {
+    const tier = modelTier(model, overrides);
+    const cur =
+      out.get(tier) ?? emptyStat({ name: "by_tier", context: { tier } });
+    out.set(tier, addToStat(cur, value));
+  }
+  return out;
+}


### PR DESCRIPTION
Most runs so far used only frontier models, where everyone cooperates and the interesting variance hides below the frontier (you noted you added some OpenRouter versions). Tagging each run by a coarse capability tier lets the leaderboard show *where* cooperation breaks down.

- **`modelTier(modelId, overrides?)`** -> `frontier | mid | small | unknown`, by a heuristic on the model id plus an `overrides` escape hatch. Tiers are deliberately coarse and tunable, not authoritative (word boundaries keep `mini` from matching inside `gemini`, etc.).
- **`statsByTier(observations)`** -> one `Stat` per tier for a metric (e.g. cooperation rate), so a single metric reads across tiers and surfaces the drop below the frontier.

Composes with the metric primitives from #20/#26: `tier` is `MetricName.context.tier`, and adjacent tiers pair with `statDelta` (#12) to test whether a drop is signal or sampling noise.

Pure `shared/` helpers, no new deps. `node:test` coverage (6 cases).

**Test:** `npx tsx --test shared/modelTier.test.ts` -> 6 pass.

Next (separate): tag runs by tier in the analysis/leaderboard path so the board shows per-tier cooperation directly.
